### PR TITLE
Fix typo in the main script

### DIFF
--- a/asyncio_telnet/asyncio_telnet.py
+++ b/asyncio_telnet/asyncio_telnet.py
@@ -109,7 +109,7 @@ class AsyncTelnet:
             try:
                 data = await asyncio.wait_for(self.read(100), timeout=0.1)
                 timer +=  0.1
-                if not data and mode != 'smart':
+                if not data and self.mode != 'smart':
                     break
                 if self.eor_support is None:
                     if WONT + EOR in data or DONT + EOR in data:


### PR DESCRIPTION
`mode != 'smart'` should be `self.mode != 'smart'`, otherwise the program may fail due to undefined variable exception